### PR TITLE
Change error to warning for missing temporary file

### DIFF
--- a/fitting/mwi_3cx_2R1R2s_dimwi.m
+++ b/fitting/mwi_3cx_2R1R2s_dimwi.m
@@ -707,11 +707,12 @@ end
 
 iterations = output.iterations;
 
-catch 
+catch ME
     x           = zeros(size(x0));
     res         = 0 ;
     exitflag    = 99;
     iterations  = 0;
+    warning('MWI:MCR:OptimizationError', getReport(ME,'extended'))
 end
 
 end

--- a/utils/set_up_output.m
+++ b/utils/set_up_output.m
@@ -55,7 +55,7 @@ if isfield(imgPara,'identifier')
 
     % check if the temporary file exists
     if ~exist([temp_prefix identifier '.mat'],'file')
-        error('Cannot detect the temporary file with the provided identifier. Please enter a valid identifier or remove the input identifier');
+        warning('MWI:IdentifierFile:NotFound', 'Cannot detect the temporary file with the provided identifier "%s". Please enter a valid identifier or remove the input identifier', identifier);
     end
 else
     % create a new identifier if not provided


### PR DESCRIPTION
I passed an `imgPara.identifier` to `mwi_3cx_2R1R2s_dimwi` to get control over the logfile naming. However, that evokes an error, which is too brutal (because it's a valid thing to do, MWI can just continue normally with the given identifier, without crashing). Hence, I changed the error to a warning.